### PR TITLE
feat: add on-demand isr revalidation endpoint and scraper trigger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\
 # Accepts either a full Google Sheets URL or a spreadsheet ID:
 DEV_GOOGLE_SHEETS_URL="https://docs.google.com/spreadsheets/d/1-RBYsKkE2gAEU9xwPv78k8DeYaPkfiybt-6i8bagEc0/edit"
 
+# On-demand ISR revalidation configuration (used by scraper in production)
+REVALIDATION_SECRET=""
+
+
 # Target restaurant URLs for scraper
 HUOLTAMO_API_URL="https://script.googleusercontent.com/a/macros/yle.fi/echo?user_content_key=AUkAhnT31DSF89GRyUPebcLX_oJz-Rkt0nXafVj3zNmfFHp8lvswkQTsNaHMrCG-lqxGmFaZIVDoRxEMxxamGgv-BmUXRUG-6Pd8NEdojaaKbu0Rj7vhaA698QYzWqv3O8pdDP06mxy_G235MxmF39xKmNWdzmgmOcZ0imeygA3tFSiXtstBnbwuoq8r9vZ4D8hAlz3EPBRtRAb323qQTqS2uphOR9KG5r63DY012Uq4p-9JQrGmOZ7O7PSZkGqdkXVzFp107HeJuz6jK11ikPvf8AppO0-Df8D_GAsh75a0NnMfXiVa8FV1-bf8YSN-Ww&lib=Mj9QMBIRZJsNk6tjp-CZc2vk6ee82Q7eC"
 ISO_PAJA_URL="https://www.hhravintolat.fi/iso-paja/"
@@ -15,3 +19,7 @@ AKSELI_URL="https://www.ninankeittio.fi/helsinki-ilmala-akseli/#lounaslista"
 PAATTARI_URL="https://nordrest.fi/restaurang/ravintola-paattari/#ruokalista"
 CAMPUS_BISTRO_URL="https://example.com/bistro-menu"
 STUDENT_CANTEEN_URL="https://example.com/canteen-menu"
+
+# On-demand ISR revalidation configuration (used by scraper in production)
+REVALIDATION_SECRET="a-secure-random-secret-key"
+FRONTEND_URL="https://yle-campus-lunch-list.vercel.app"

--- a/apps/nextjs/src/app/api/revalidate/route.ts
+++ b/apps/nextjs/src/app/api/revalidate/route.ts
@@ -1,0 +1,116 @@
+import type { NextRequest } from "next/server";
+import { revalidatePath } from "next/cache";
+
+import { RESTAURANT_CONFIGS } from "~/config/restaurants";
+import { env } from "~/env";
+
+function extractSecret(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader?.startsWith("Bearer ")) {
+    return authHeader.slice(7).trim();
+  }
+
+  const customHeader = request.headers.get("x-revalidate-secret");
+  if (customHeader) {
+    return customHeader.trim();
+  }
+
+  const querySecret = request.nextUrl.searchParams.get("secret");
+  if (querySecret) {
+    return querySecret.trim();
+  }
+
+  return null;
+}
+
+function authenticateRequest(request: NextRequest): {
+  authorized: boolean;
+  error?: string;
+  status?: number;
+} {
+  const expectedSecret = env.REVALIDATION_SECRET?.trim();
+
+  // If secret is set, enforce matching token
+  if (expectedSecret) {
+    const providedSecret = extractSecret(request);
+    if (!providedSecret || providedSecret !== expectedSecret) {
+      return {
+        authorized: false,
+        error: "Unauthorized: Invalid or missing secret token",
+        status: 401,
+      };
+    }
+    return { authorized: true };
+  }
+
+  // If secret is not set, reject in production for safety
+  if (env.NODE_ENV === "production") {
+    return {
+      authorized: false,
+      error: "Server misconfiguration: REVALIDATION_SECRET is not set",
+      status: 500,
+    };
+  }
+
+  // Allow in development mode if no secret configured
+  return { authorized: true };
+}
+
+function handleRevalidation(request: NextRequest) {
+  const auth = authenticateRequest(request);
+  if (!auth.authorized) {
+    return Response.json(
+      { error: auth.error },
+      {
+        status: auth.status ?? 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const revalidatedPaths: string[] = [];
+
+  // Check for specific target path in query or json body
+  const customPath = request.nextUrl.searchParams.get("path");
+  if (customPath) {
+    revalidatePath(customPath);
+    revalidatedPaths.push(customPath);
+  } else {
+    // Revalidate root layout tree (all nested pages)
+    revalidatePath("/", "layout");
+    revalidatedPaths.push("/ (layout)");
+
+    // Explicitly revalidate key routes
+    revalidatePath("/");
+    revalidatedPaths.push("/");
+
+    revalidatePath("/api/current-day-menus");
+    revalidatedPaths.push("/api/current-day-menus");
+
+    for (const config of RESTAURANT_CONFIGS) {
+      const restaurantPath = `/restaurant/${config.id}`;
+      revalidatePath(restaurantPath);
+      revalidatedPaths.push(restaurantPath);
+    }
+  }
+
+  return Response.json(
+    {
+      revalidated: true,
+      paths: revalidatedPaths,
+      timestamp: new Date().toISOString(),
+    },
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+export function POST(request: NextRequest) {
+  return handleRevalidation(request);
+}
+
+export function GET(request: NextRequest) {
+  return handleRevalidation(request);
+}

--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -20,6 +20,7 @@ export const env = createEnv({
     GOOGLE_SHEETS_OPENING_HOURS_URL: z.string().optional(),
     GOOGLE_SERVICE_ACCOUNT_EMAIL: z.string().optional(),
     GOOGLE_PRIVATE_KEY: z.string().optional(),
+    REVALIDATION_SECRET: z.string().optional(),
   },
   client: {
     // Client environment variables if needed

--- a/apps/scraper/src/index.ts
+++ b/apps/scraper/src/index.ts
@@ -38,6 +38,7 @@ import {
   PASILAN_LINKKI_RESTAURANT_ID,
   PASILAN_LINKKI_RESTAURANT_NAME,
 } from "./fetchers/pasilan-linkki.js";
+import { triggerRevalidation } from "./revalidate.js";
 import { updateGoogleSheet, updateGoogleSheetOpeningHours } from "./sheets.js";
 
 /**
@@ -223,6 +224,10 @@ async function main() {
   } catch (error) {
     console.error("Error processing opening hours:", error);
   }
+
+  // 9. Revalidate frontend cache (in production)
+  console.log("\nTriggering on-demand frontend revalidation...");
+  await triggerRevalidation();
 
   console.log("\n=== Campus Lunch List Scraper Finished ===");
 }

--- a/apps/scraper/src/revalidate.test.ts
+++ b/apps/scraper/src/revalidate.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { triggerRevalidation } from "./revalidate.js";
+
+void describe("triggerRevalidation", () => {
+  void it("skips revalidation when not in production and force is not set", async () => {
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+
+    try {
+      const result = await triggerRevalidation({
+        frontendUrl: "https://campus-lunch.example.com",
+      });
+      assert.equal(result.skipped, true);
+      assert.equal(result.success, true);
+    } finally {
+      process.env.NODE_ENV = origEnv;
+    }
+  });
+
+  void it("returns error if frontend URL is missing in production", async () => {
+    const origEnv = process.env.NODE_ENV;
+    const origUrl = process.env.FRONTEND_URL;
+    process.env.NODE_ENV = "production";
+    delete process.env.FRONTEND_URL;
+    delete process.env.REVALIDATE_URL;
+
+    try {
+      const result = await triggerRevalidation();
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /FRONTEND_URL/);
+    } finally {
+      process.env.NODE_ENV = origEnv;
+      process.env.FRONTEND_URL = origUrl;
+    }
+  });
+
+  void it("successfully calls revalidation endpoint when forced or in production", async () => {
+    const origFetch = globalThis.fetch;
+    let requestedUrl = "";
+    let authHeader = "";
+    let customHeader = "";
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requestedUrl =
+        typeof url === "string"
+          ? url
+          : url instanceof URL
+            ? url.toString()
+            : url.url;
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      authHeader = headers.Authorization ?? "";
+      customHeader = headers["x-revalidate-secret"] ?? "";
+
+      return Promise.resolve(
+        new Response(JSON.stringify({ revalidated: true, paths: ["/"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await triggerRevalidation({
+        frontendUrl: "https://campus-lunch.example.com/",
+        secret: "test-secret-123",
+        force: true,
+      });
+
+      assert.equal(result.success, true);
+      assert.equal(result.status, 200);
+      assert.equal(
+        requestedUrl,
+        "https://campus-lunch.example.com/api/revalidate",
+      );
+      assert.equal(authHeader, "Bearer test-secret-123");
+      assert.equal(customHeader, "test-secret-123");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  void it("handles HTTP error status codes gracefully", async () => {
+    const origFetch = globalThis.fetch;
+
+    globalThis.fetch = (() => {
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: "Unauthorized" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch;
+
+    try {
+      const result = await triggerRevalidation({
+        frontendUrl: "https://campus-lunch.example.com",
+        secret: "wrong-secret",
+        force: true,
+      });
+
+      assert.equal(result.success, false);
+      assert.equal(result.status, 401);
+      assert.match(result.error ?? "", /HTTP 401/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+
+  void it("catches network errors and does not throw", async () => {
+    const origFetch = globalThis.fetch;
+
+    globalThis.fetch = (() => {
+      return Promise.reject(new Error("Connection refused"));
+    }) as typeof fetch;
+
+    try {
+      const result = await triggerRevalidation({
+        frontendUrl: "http://localhost:3000",
+        force: true,
+      });
+
+      assert.equal(result.success, false);
+      assert.match(result.error ?? "", /Connection refused/);
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});

--- a/apps/scraper/src/revalidate.ts
+++ b/apps/scraper/src/revalidate.ts
@@ -1,0 +1,91 @@
+export interface RevalidateOptions {
+  frontendUrl?: string;
+  secret?: string;
+  force?: boolean;
+}
+
+export interface RevalidateResult {
+  success: boolean;
+  skipped?: boolean;
+  error?: string;
+  status?: number;
+}
+
+/**
+ * Triggers on-demand ISR revalidation on the Next.js frontend application.
+ * Note: Per project requirements, revalidation is skipped in non-production environments
+ * (NODE_ENV !== "production") unless explicitly forced.
+ */
+export async function triggerRevalidation(
+  options?: RevalidateOptions,
+): Promise<RevalidateResult> {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  if (!isProduction && !options?.force) {
+    console.log(
+      "[Revalidate] Skipping frontend revalidation (not in production mode).",
+    );
+    return { success: true, skipped: true };
+  }
+
+  const rawUrl =
+    options?.frontendUrl ??
+    process.env.FRONTEND_URL ??
+    process.env.REVALIDATE_URL;
+
+  if (!rawUrl) {
+    const msg =
+      "[Revalidate] FRONTEND_URL (or REVALIDATE_URL) is not configured. Skipping revalidation.";
+    console.warn(msg);
+    return { success: false, error: msg };
+  }
+
+  const secret = options?.secret ?? process.env.REVALIDATION_SECRET;
+  const baseUrl = rawUrl.replace(/\/+$/, "");
+  const targetEndpoint = `${baseUrl}/api/revalidate`;
+
+  console.log(`[Revalidate] Triggering revalidation at ${targetEndpoint}...`);
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (secret) {
+    headers.Authorization = `Bearer ${secret}`;
+    headers["x-revalidate-secret"] = secret;
+  }
+
+  try {
+    const response = await fetch(targetEndpoint, {
+      method: "POST",
+      headers,
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      const errorMsg = `Revalidation request failed with HTTP ${response.status}: ${errorBody}`;
+      console.error(`[Revalidate] ${errorMsg}`);
+      return {
+        success: false,
+        status: response.status,
+        error: errorMsg,
+      };
+    }
+
+    const data = (await response.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    console.log(
+      "[Revalidate] Successfully revalidated frontend cache:",
+      JSON.stringify(data),
+    );
+    return { success: true, status: response.status };
+  } catch (error) {
+    const errorMsg =
+      error instanceof Error ? error.message : "Unknown network error";
+    console.error(`[Revalidate] Error triggering revalidation: ${errorMsg}`);
+    return { success: false, error: errorMsg };
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -72,7 +72,10 @@
     "SCRAPE_DATE",
     "CAMPUS_BISTRO_URL",
     "STUDENT_CANTEEN_URL",
-    "PORT"
+    "PORT",
+    "REVALIDATION_SECRET",
+    "FRONTEND_URL",
+    "REVALIDATE_URL"
   ],
   "globalPassThroughEnv": [
     "NODE_ENV",


### PR DESCRIPTION
## Summary

Adds an on-demand Incremental Static Regeneration (ISR) revalidation route in the Next.js frontend application and integrates automatic cache revalidation triggering into the Scraper CLI for production runs.

Addresses #50.

---

## Changes

### Next.js App (`apps/nextjs`)
- **Revalidation API Route (`/api/revalidate`)**:
  - Accepts `POST` and `GET` requests.
  - Authenticates via `Authorization: Bearer <secret>`, `x-revalidate-secret` header, or `?secret=<secret>` against `REVALIDATION_SECRET`.
  - Revalidates the root layout tree (`/`), homepage, legacy JSON API (`/api/current-day-menus`), and all restaurant detail pages (`/restaurant/[id]`).
- **Environment Schema (`src/env.ts`)**:
  - Added `REVALIDATION_SECRET: z.string().optional()`.

### Scraper App (`apps/scraper`)
- **Revalidation Client (`src/revalidate.ts`)**:
  - Added `triggerRevalidation()` helper.
  - Skips revalidation automatically when running in development/test (`NODE_ENV !== "production"`).
  - In production, issues a `POST` request to `${FRONTEND_URL}/api/revalidate` with a 10s timeout and resilient error handling.
- **Pipeline Integration (`src/index.ts`)**:
  - Calls `triggerRevalidation()` after all restaurant tabs have synchronized with Google Sheets.
- **Unit Tests (`src/revalidate.test.ts`)**:
  - Added unit test suite covering non-prod skipping, missing URL handling, successful calls with auth headers, HTTP error handling, and network exception resilience.

### Configuration
- Added `REVALIDATION_SECRET`, `FRONTEND_URL`, and `REVALIDATE_URL` to `turbo.json` `globalEnv`.
- Updated `.env.example` with documentation and sample values.

---

## Verification
- All 68 unit tests passing (`pnpm --filter @acme/scraper test`).
- TypeScript typechecks passing on `@acme/nextjs` and `@acme/scraper` (`tsc --noEmit`).
- ESLint and Prettier checks passing.

Closes #50
