### PR TITLE
perf(nextjs): increase page cache time to prevent google sheets quota limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Other key directories:
 flowchart LR
     A[Restaurant Sources: API / RSS / HTML] -->|Scraper fetchers| B[apps/scraper CLI]
     B -->|JWT Auth & Batch Write| C[(Google Sheets CMS)]
-    C -->|JWT Auth & batchGet / ISR 300s| D[apps/nextjs App]
+    C -->|JWT Auth & batchGet / ISR 3600s| D[apps/nextjs App]
     D -->|Render UI / JSON API| E[End User / API Clients]
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pnpm test
 ## Page revalidation & Data flow
 
 1. **Scraping & Storage**: The scraper fetches menu data daily (or manually) from diverse sources and writes the formatted dishes to individual restaurant sheets in Google Sheets.
-2. **Next.js Caching**: The Next.js frontend reads menu data from Google Sheets using the Google Sheets API, cached with time-based ISR (`export const revalidate = 300`, revalidating every 5 minutes).
+2. **Next.js Caching**: The Next.js frontend reads menu data from Google Sheets using the Google Sheets API, cached with time-based ISR (`export const revalidate = 3600`, revalidating every 1 hour).
 
 ## Lunch list data sources
 

--- a/apps/nextjs/src/app/api/current-day-menus/route.ts
+++ b/apps/nextjs/src/app/api/current-day-menus/route.ts
@@ -10,8 +10,8 @@ import { RESTAURANT_CONFIGS } from "~/config/restaurants";
 import { isCurrentDate } from "~/lib/dates";
 import { fetchRestaurantsFromGoogleSheets } from "~/lib/sheets";
 
-// Revalidation interval (5 minutes)
-export const revalidate = 300;
+// Revalidation interval (1 hour)
+export const revalidate = 3600;
 
 /**
  * Converts a kebab-case restaurant ID to camelCase (e.g. "iso-paja" -> "isoPaja", "studio-10" -> "studio10").
@@ -101,7 +101,7 @@ export async function GET() {
       status: 200,
       headers: {
         "Content-Type": "application/json",
-        "Cache-Control": "s-maxage=300, stale-while-revalidate=600",
+        "Cache-Control": "s-maxage=3600, stale-while-revalidate=7200",
       },
     });
   } catch (err) {

--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -4,8 +4,8 @@ import { getSortedRestaurantsWithMetadata } from "~/config/restaurants";
 import { getTodayFormattedString } from "~/lib/dates";
 import { fetchRestaurantsFromGoogleSheets } from "~/lib/sheets";
 
-// Configure Next.js ISR revalidation interval (5 minutes)
-export const revalidate = 300;
+// Configure Next.js ISR revalidation interval (1 hour)
+export const revalidate = 3600;
 
 export default async function HomePage() {
   const {

--- a/apps/nextjs/src/app/restaurant/[id]/page.tsx
+++ b/apps/nextjs/src/app/restaurant/[id]/page.tsx
@@ -16,8 +16,8 @@ import {
 } from "~/lib/dates";
 import { fetchRestaurantsFromGoogleSheets } from "~/lib/sheets";
 
-// Configure Next.js ISR revalidation interval (5 minutes)
-export const revalidate = 300;
+// Configure Next.js ISR revalidation interval (1 hour)
+export const revalidate = 3600;
 
 interface RestaurantPageProps {
   params: Promise<{ id: string }>;

--- a/apps/nextjs/src/lib/sheets.ts
+++ b/apps/nextjs/src/lib/sheets.ts
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { google } from "googleapis";
 
 import type {
@@ -130,83 +131,88 @@ function formatRestaurantTitle(id: string): string {
     .join(" ");
 }
 
-export async function fetchOpeningHoursFromGoogleSheets(): Promise<
-  Record<string, RestaurantOpeningHours>
-> {
-  const { spreadsheetId } = getOpeningHoursSpreadsheetResolution();
-  const clientEmail = env.GOOGLE_SERVICE_ACCOUNT_EMAIL?.trim();
-  let privateKey = env.GOOGLE_PRIVATE_KEY;
+export const fetchOpeningHoursFromGoogleSheets = cache(
+  async function fetchOpeningHoursFromGoogleSheets(): Promise<
+    Record<string, RestaurantOpeningHours>
+  > {
+    const { spreadsheetId } = getOpeningHoursSpreadsheetResolution();
+    const clientEmail = env.GOOGLE_SERVICE_ACCOUNT_EMAIL?.trim();
+    let privateKey = env.GOOGLE_PRIVATE_KEY;
 
-  if (privateKey) {
-    privateKey = privateKey.trim();
-    if (
-      (privateKey.startsWith('"') && privateKey.endsWith('"')) ||
-      (privateKey.startsWith("'") && privateKey.endsWith("'"))
-    ) {
-      privateKey = privateKey.slice(1, -1);
+    if (privateKey) {
+      privateKey = privateKey.trim();
+      if (
+        (privateKey.startsWith('"') && privateKey.endsWith('"')) ||
+        (privateKey.startsWith("'") && privateKey.endsWith("'"))
+      ) {
+        privateKey = privateKey.slice(1, -1);
+      }
+      privateKey = privateKey.replace(/\\n/g, "\n");
     }
-    privateKey = privateKey.replace(/\\n/g, "\n");
-  }
 
-  if (!spreadsheetId || !clientEmail || !privateKey) {
-    return {};
-  }
-
-  try {
-    const auth = new google.auth.JWT({
-      email: clientEmail,
-      key: privateKey,
-      scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
-    });
-
-    const sheets = google.sheets({ version: "v4", auth });
-    const spreadsheet = await sheets.spreadsheets.get({ spreadsheetId });
-    const sheetTitles = (spreadsheet.data.sheets ?? [])
-      .map((s) => s.properties?.title)
-      .filter((t): t is string => typeof t === "string" && t.length > 0);
-
-    const targetTab = sheetTitles.includes("opening-hours")
-      ? "opening-hours"
-      : sheetTitles[0];
-
-    if (!targetTab) {
+    if (!spreadsheetId || !clientEmail || !privateKey) {
       return {};
     }
 
-    const response = await sheets.spreadsheets.values.get({
-      spreadsheetId,
-      range: `'${targetTab}'!A2:F`,
-    });
+    try {
+      const auth = new google.auth.JWT({
+        email: clientEmail,
+        key: privateKey,
+        scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+      });
 
-    const rows = response.data.values ?? [];
-    const mapping: Record<string, RestaurantOpeningHours> = {};
+      const sheets = google.sheets({ version: "v4", auth });
+      const spreadsheet = await sheets.spreadsheets.get({ spreadsheetId });
+      const sheetTitles = (spreadsheet.data.sheets ?? [])
+        .map((s) => s.properties?.title)
+        .filter((t): t is string => typeof t === "string" && t.length > 0);
 
-    for (const row of rows) {
-      const restaurantId = safeString(row[0]);
-      if (!restaurantId) continue;
+      const targetTab = sheetTitles.includes("opening-hours")
+        ? "opening-hours"
+        : sheetTitles[0];
 
-      const restaurantName = safeString(row[1]);
-      const openHours = safeString(row[2]);
-      const lunchHours = safeString(row[3]);
-      const rawText = safeString(row[4]);
-      const lastUpdated = safeString(row[5]) || new Date().toISOString();
+      if (!targetTab) {
+        return {};
+      }
 
-      mapping[restaurantId] = {
-        restaurantId,
-        restaurantName,
-        openHours: openHours || undefined,
-        lunchHours: lunchHours || undefined,
-        rawText: rawText || undefined,
-        lastUpdated,
-      };
+      const response = await sheets.spreadsheets.values.get({
+        spreadsheetId,
+        range: `'${targetTab}'!A2:F`,
+      });
+
+      const rows = response.data.values ?? [];
+      const mapping: Record<string, RestaurantOpeningHours> = {};
+
+      for (const row of rows) {
+        const restaurantId = safeString(row[0]);
+        if (!restaurantId) continue;
+
+        const restaurantName = safeString(row[1]);
+        const openHours = safeString(row[2]);
+        const lunchHours = safeString(row[3]);
+        const rawText = safeString(row[4]);
+        const lastUpdated = safeString(row[5]) || new Date().toISOString();
+
+        mapping[restaurantId] = {
+          restaurantId,
+          restaurantName,
+          openHours: openHours || undefined,
+          lunchHours: lunchHours || undefined,
+          rawText: rawText || undefined,
+          lastUpdated,
+        };
+      }
+
+      return mapping;
+    } catch (error) {
+      console.error(
+        "[Google Sheets] Error fetching opening hours data:",
+        error,
+      );
+      return {};
     }
-
-    return mapping;
-  } catch (error) {
-    console.error("[Google Sheets] Error fetching opening hours data:", error);
-    return {};
-  }
-}
+  },
+);
 
 export interface FetchResult {
   restaurants: Restaurant[];
@@ -216,181 +222,183 @@ export interface FetchResult {
   isDev: boolean;
 }
 
-export async function fetchRestaurantsFromGoogleSheets(): Promise<FetchResult> {
-  const { spreadsheetId, source, isDev } = getSpreadsheetResolution();
-  const clientEmail = env.GOOGLE_SERVICE_ACCOUNT_EMAIL?.trim();
-  let privateKey = env.GOOGLE_PRIVATE_KEY;
+export const fetchRestaurantsFromGoogleSheets = cache(
+  async function fetchRestaurantsFromGoogleSheets(): Promise<FetchResult> {
+    const { spreadsheetId, source, isDev } = getSpreadsheetResolution();
+    const clientEmail = env.GOOGLE_SERVICE_ACCOUNT_EMAIL?.trim();
+    let privateKey = env.GOOGLE_PRIVATE_KEY;
 
-  if (privateKey) {
-    privateKey = privateKey.trim();
-    if (
-      (privateKey.startsWith('"') && privateKey.endsWith('"')) ||
-      (privateKey.startsWith("'") && privateKey.endsWith("'"))
-    ) {
-      privateKey = privateKey.slice(1, -1);
+    if (privateKey) {
+      privateKey = privateKey.trim();
+      if (
+        (privateKey.startsWith('"') && privateKey.endsWith('"')) ||
+        (privateKey.startsWith("'") && privateKey.endsWith("'"))
+      ) {
+        privateKey = privateKey.slice(1, -1);
+      }
+      privateKey = privateKey.replace(/\\n/g, "\n");
     }
-    privateKey = privateKey.replace(/\\n/g, "\n");
-  }
 
-  if (!spreadsheetId) {
-    return {
-      restaurants: [],
-      error:
-        "Google Sheets ID is not configured. Please set GOOGLE_SHEETS_ID or DEV_GOOGLE_SHEETS_URL.",
-      isDev,
-    };
-  }
-
-  if (!clientEmail || !privateKey) {
-    return {
-      restaurants: [],
-      error:
-        "Google Service Account credentials (GOOGLE_SERVICE_ACCOUNT_EMAIL or GOOGLE_PRIVATE_KEY) are missing.",
-      resolvedSpreadsheetId: spreadsheetId,
-      source,
-      isDev,
-    };
-  }
-
-  try {
-    const auth = new google.auth.JWT({
-      email: clientEmail,
-      key: privateKey,
-      scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
-    });
-
-    const sheets = google.sheets({ version: "v4", auth });
-
-    // Concurrently fetch menu metadata and opening hours
-    const [spreadsheet, openingHoursMap] = await Promise.all([
-      sheets.spreadsheets.get({ spreadsheetId }),
-      fetchOpeningHoursFromGoogleSheets(),
-    ]);
-
-    const sheetTitles = (spreadsheet.data.sheets ?? [])
-      .map((s) => s.properties?.title)
-      .filter((t): t is string => typeof t === "string" && t.length > 0);
-
-    if (sheetTitles.length === 0) {
+    if (!spreadsheetId) {
       return {
         restaurants: [],
-        error: "Spreadsheet contains no sheet tabs.",
+        error:
+          "Google Sheets ID is not configured. Please set GOOGLE_SHEETS_ID or DEV_GOOGLE_SHEETS_URL.",
+        isDev,
+      };
+    }
+
+    if (!clientEmail || !privateKey) {
+      return {
+        restaurants: [],
+        error:
+          "Google Service Account credentials (GOOGLE_SERVICE_ACCOUNT_EMAIL or GOOGLE_PRIVATE_KEY) are missing.",
         resolvedSpreadsheetId: spreadsheetId,
         source,
         isDev,
       };
     }
 
-    const ranges = sheetTitles.map((title) => `'${title}'!A2:F`);
-    const batchResponse = await sheets.spreadsheets.values.batchGet({
-      spreadsheetId,
-      ranges,
-    });
+    try {
+      const auth = new google.auth.JWT({
+        email: clientEmail,
+        key: privateKey,
+        scopes: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+      });
 
-    const todayIsoDate = new Intl.DateTimeFormat("en-CA", {
-      timeZone: "Europe/Helsinki",
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).format(new Date());
+      const sheets = google.sheets({ version: "v4", auth });
 
-    const restaurants: Restaurant[] = [];
-    const valueRanges = batchResponse.data.valueRanges ?? [];
+      // Concurrently fetch menu metadata and opening hours
+      const [spreadsheet, openingHoursMap] = await Promise.all([
+        sheets.spreadsheets.get({ spreadsheetId }),
+        fetchOpeningHoursFromGoogleSheets(),
+      ]);
 
-    for (let i = 0; i < sheetTitles.length; i++) {
-      const tabTitle = sheetTitles[i];
-      if (!tabTitle) continue;
+      const sheetTitles = (spreadsheet.data.sheets ?? [])
+        .map((s) => s.properties?.title)
+        .filter((t): t is string => typeof t === "string" && t.length > 0);
 
-      const valRange = valueRanges[i];
-      const rawRows = valRange?.values ?? [];
+      if (sheetTitles.length === 0) {
+        return {
+          restaurants: [],
+          error: "Spreadsheet contains no sheet tabs.",
+          resolvedSpreadsheetId: spreadsheetId,
+          source,
+          isDev,
+        };
+      }
 
-      if (rawRows.length === 0) {
-        // Tab exists but has no rows currently published
+      const ranges = sheetTitles.map((title) => `'${title}'!A2:F`);
+      const batchResponse = await sheets.spreadsheets.values.batchGet({
+        spreadsheetId,
+        ranges,
+      });
+
+      const todayIsoDate = new Intl.DateTimeFormat("en-CA", {
+        timeZone: "Europe/Helsinki",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      }).format(new Date());
+
+      const restaurants: Restaurant[] = [];
+      const valueRanges = batchResponse.data.valueRanges ?? [];
+
+      for (let i = 0; i < sheetTitles.length; i++) {
+        const tabTitle = sheetTitles[i];
+        if (!tabTitle) continue;
+
+        const valRange = valueRanges[i];
+        const rawRows = valRange?.values ?? [];
+
+        if (rawRows.length === 0) {
+          // Tab exists but has no rows currently published
+          restaurants.push({
+            id: tabTitle,
+            name: formatRestaurantTitle(tabTitle),
+            openingHours: openingHoursMap[tabTitle],
+            lastUpdated: new Date().toISOString(),
+            menus: [
+              {
+                date: todayIsoDate,
+                items: [],
+              },
+            ],
+          });
+          continue;
+        }
+
+        // First valid row gives restaurant metadata
+        const firstRow = rawRows[0];
+        const rowRestaurantId = safeString(firstRow?.[0]);
+        const rowRestaurantName = safeString(firstRow?.[1]);
+        const rowMenuDate = safeString(firstRow?.[2]);
+        const rowLastUpdated = safeString(firstRow?.[5]);
+
+        const restaurantId =
+          rowRestaurantId.length > 0 ? rowRestaurantId : tabTitle;
+        const restaurantName =
+          rowRestaurantName.length > 0
+            ? rowRestaurantName
+            : formatRestaurantTitle(tabTitle);
+        const menuDate = rowMenuDate.length > 0 ? rowMenuDate : todayIsoDate;
+        const lastUpdated =
+          rowLastUpdated.length > 0 ? rowLastUpdated : new Date().toISOString();
+
+        const items: MenuItem[] = [];
+        for (const row of rawRows) {
+          const itemText = safeString(row[3]);
+          if (!itemText) continue;
+
+          const dietaryRaw = safeString(row[4]);
+          const dietaryFlags =
+            dietaryRaw.length > 0
+              ? dietaryRaw
+                  .split(",")
+                  .map((f) => f.trim())
+                  .filter((f) => f.length > 0)
+              : [];
+
+          items.push({
+            name: itemText,
+            dietaryFlags,
+          });
+        }
+
         restaurants.push({
-          id: tabTitle,
-          name: formatRestaurantTitle(tabTitle),
-          openingHours: openingHoursMap[tabTitle],
-          lastUpdated: new Date().toISOString(),
+          id: restaurantId,
+          name: restaurantName,
+          openingHours:
+            openingHoursMap[restaurantId] ?? openingHoursMap[tabTitle],
+          lastUpdated,
           menus: [
             {
-              date: todayIsoDate,
-              items: [],
+              date: menuDate,
+              items,
             },
           ],
         });
-        continue;
       }
 
-      // First valid row gives restaurant metadata
-      const firstRow = rawRows[0];
-      const rowRestaurantId = safeString(firstRow?.[0]);
-      const rowRestaurantName = safeString(firstRow?.[1]);
-      const rowMenuDate = safeString(firstRow?.[2]);
-      const rowLastUpdated = safeString(firstRow?.[5]);
-
-      const restaurantId =
-        rowRestaurantId.length > 0 ? rowRestaurantId : tabTitle;
-      const restaurantName =
-        rowRestaurantName.length > 0
-          ? rowRestaurantName
-          : formatRestaurantTitle(tabTitle);
-      const menuDate = rowMenuDate.length > 0 ? rowMenuDate : todayIsoDate;
-      const lastUpdated =
-        rowLastUpdated.length > 0 ? rowLastUpdated : new Date().toISOString();
-
-      const items: MenuItem[] = [];
-      for (const row of rawRows) {
-        const itemText = safeString(row[3]);
-        if (!itemText) continue;
-
-        const dietaryRaw = safeString(row[4]);
-        const dietaryFlags =
-          dietaryRaw.length > 0
-            ? dietaryRaw
-                .split(",")
-                .map((f) => f.trim())
-                .filter((f) => f.length > 0)
-            : [];
-
-        items.push({
-          name: itemText,
-          dietaryFlags,
-        });
-      }
-
-      restaurants.push({
-        id: restaurantId,
-        name: restaurantName,
-        openingHours:
-          openingHoursMap[restaurantId] ?? openingHoursMap[tabTitle],
-        lastUpdated,
-        menus: [
-          {
-            date: menuDate,
-            items,
-          },
-        ],
-      });
+      return {
+        restaurants,
+        resolvedSpreadsheetId: spreadsheetId,
+        source,
+        isDev,
+      };
+    } catch (error) {
+      console.error("[Google Sheets] Error fetching sheet data:", error);
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to fetch menu data from Google Sheets.";
+      return {
+        restaurants: [],
+        error: errorMessage,
+        resolvedSpreadsheetId: spreadsheetId,
+        source,
+        isDev,
+      };
     }
-
-    return {
-      restaurants,
-      resolvedSpreadsheetId: spreadsheetId,
-      source,
-      isDev,
-    };
-  } catch (error) {
-    console.error("[Google Sheets] Error fetching sheet data:", error);
-    const errorMessage =
-      error instanceof Error
-        ? error.message
-        : "Failed to fetch menu data from Google Sheets.";
-    return {
-      restaurants: [],
-      error: errorMessage,
-      resolvedSpreadsheetId: spreadsheetId,
-      source,
-      isDev,
-    };
-  }
-}
+  },
+);


### PR DESCRIPTION
### Summary of Changes

1. **Increase ISR Revalidation Interval (`apps/nextjs`)**:
   - `apps/nextjs/src/app/page.tsx`: Increased ISR `revalidate` from 300 seconds (5 min) to 3600 seconds (1 hour).
   - `apps/nextjs/src/app/restaurant/[id]/page.tsx`: Increased ISR `revalidate` from 300 seconds (5 min) to 3600 seconds (1 hour).
   - `apps/nextjs/src/app/api/current-day-menus/route.ts`: Increased `revalidate` to 3600 seconds and updated `Cache-Control` header to `s-maxage=3600, stale-while-revalidate=7200`.

2. **Per-Request Google Sheets Memoization (`apps/nextjs/src/lib/sheets.ts`)**:
   - Wrapped `fetchRestaurantsFromGoogleSheets` and `fetchOpeningHoursFromGoogleSheets` with React `cache()` to deduplicate concurrent requests across server components (e.g. `generateMetadata` and `RestaurantPage`) within a single render cycle.

3. **Documentation**:
   - Updated `README.md` and `AGENTS.md` to reflect the 1-hour ISR cache configuration.