### PR TITLE
feat(nextjs): add three-column desktop breakpoint to masonry layout

### DIFF
--- a/apps/nextjs/src/app/page.tsx
+++ b/apps/nextjs/src/app/page.tsx
@@ -19,7 +19,7 @@ export default async function HomePage() {
   const todayStr = getTodayFormattedString();
 
   return (
-    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+    <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:max-w-7xl lg:px-8">
       {error ? (
         <div
           role="alert"

--- a/apps/nextjs/src/components/restaurant-view.tsx
+++ b/apps/nextjs/src/components/restaurant-view.tsx
@@ -111,38 +111,7 @@ export function RestaurantView({
           </Button>
         </div>
       ) : (
-        <>
-          {/* Mobile view: single column */}
-          <div className="flex flex-col gap-6 md:hidden">
-            {visibleRestaurants.map((restaurant) => (
-              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
-            ))}
-          </div>
-
-          {/* Desktop view: two-column masonry with alternating items */}
-          <div className="hidden gap-6 md:flex md:flex-row md:items-start">
-            <div className="flex flex-1 flex-col gap-6">
-              {visibleRestaurants
-                .filter((_, idx) => idx % 2 === 0)
-                .map((restaurant) => (
-                  <RestaurantListItem
-                    key={restaurant.id}
-                    restaurant={restaurant}
-                  />
-                ))}
-            </div>
-            <div className="flex flex-1 flex-col gap-6">
-              {visibleRestaurants
-                .filter((_, idx) => idx % 2 === 1)
-                .map((restaurant) => (
-                  <RestaurantListItem
-                    key={restaurant.id}
-                    restaurant={restaurant}
-                  />
-                ))}
-            </div>
-          </div>
-        </>
+        <RestaurantListMasonry restaurants={visibleRestaurants} />
       )}
 
       {/* Hidden restaurants section */}
@@ -164,36 +133,7 @@ export function RestaurantView({
             </span>
           </div>
 
-          {/* Mobile view: single column */}
-          <div className="flex flex-col gap-6 md:hidden">
-            {hiddenRestaurants.map((restaurant) => (
-              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
-            ))}
-          </div>
-
-          {/* Desktop view: two-column masonry with alternating items */}
-          <div className="hidden gap-6 md:flex md:flex-row md:items-start">
-            <div className="flex flex-1 flex-col gap-6">
-              {hiddenRestaurants
-                .filter((_, idx) => idx % 2 === 0)
-                .map((restaurant) => (
-                  <RestaurantListItem
-                    key={restaurant.id}
-                    restaurant={restaurant}
-                  />
-                ))}
-            </div>
-            <div className="flex flex-1 flex-col gap-6">
-              {hiddenRestaurants
-                .filter((_, idx) => idx % 2 === 1)
-                .map((restaurant) => (
-                  <RestaurantListItem
-                    key={restaurant.id}
-                    restaurant={restaurant}
-                  />
-                ))}
-            </div>
-          </div>
+          <RestaurantListMasonry restaurants={hiddenRestaurants} />
         </section>
       )}
 
@@ -204,6 +144,66 @@ export function RestaurantView({
           restaurants={restaurants}
         />
       )}
+    </>
+  );
+}
+
+interface RestaurantListMasonryProps {
+  restaurants: Restaurant[];
+}
+
+function RestaurantListMasonry({ restaurants }: RestaurantListMasonryProps) {
+  return (
+    <>
+      {/* Mobile view: single column */}
+      <div className="flex flex-col gap-6 md:hidden">
+        {restaurants.map((restaurant) => (
+          <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+        ))}
+      </div>
+
+      {/* Tablet / Medium view: two-column masonry with alternating items */}
+      <div className="hidden gap-6 md:flex md:flex-row md:items-start lg:hidden">
+        <div className="flex flex-1 flex-col gap-6">
+          {restaurants
+            .filter((_, idx) => idx % 2 === 0)
+            .map((restaurant) => (
+              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+            ))}
+        </div>
+        <div className="flex flex-1 flex-col gap-6">
+          {restaurants
+            .filter((_, idx) => idx % 2 === 1)
+            .map((restaurant) => (
+              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+            ))}
+        </div>
+      </div>
+
+      {/* Large desktop view: three-column masonry with alternating items */}
+      <div className="hidden gap-6 lg:flex lg:flex-row lg:items-start">
+        <div className="flex flex-1 flex-col gap-6">
+          {restaurants
+            .filter((_, idx) => idx % 3 === 0)
+            .map((restaurant) => (
+              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+            ))}
+        </div>
+        <div className="flex flex-1 flex-col gap-6">
+          {restaurants
+            .filter((_, idx) => idx % 3 === 1)
+            .map((restaurant) => (
+              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+            ))}
+        </div>
+        <div className="flex flex-1 flex-col gap-6">
+          {restaurants
+            .filter((_, idx) => idx % 3 === 2)
+            .map((restaurant) => (
+              <RestaurantListItem key={restaurant.id} restaurant={restaurant} />
+            ))}
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary

This PR adds a three-column masonry layout breakpoint for desktop displays (`lg` / 1024px+).

### Changes
- **Responsive Masonry Breakpoints**:
  - `< md`: 1-column layout for mobile
  - `md` to `lg`: 2-column masonry layout
  - `lg`+: 3-column masonry layout
- **DRY Component Refactor**: Extracted `RestaurantListMasonry` subcomponent in [`restaurant-view.tsx`](file:///Users/kauppjo/.gemini/antigravity/worktrees/yle-campus-lunch-list/add_three_column_breakpoint/apps/nextjs/src/components/restaurant-view.tsx) shared by visible and hidden restaurant sections.
- **Container Sizing**: Expanded [`page.tsx`](file:///Users/kauppjo/.gemini/antigravity/worktrees/yle-campus-lunch-list/add_three_column_breakpoint/apps/nextjs/src/app/page.tsx) container max-width to `lg:max-w-7xl` so three columns have adequate breathing room on desktop displays.

### Verification
- `pnpm typecheck` passed cleanly across all workspace packages
- `pnpm lint` and `pnpm format` passed
- `pnpm --filter @acme/scraper test` passed (78/78 tests)
- Next.js production build succeeded
- Dev server tested and verified with local and live data